### PR TITLE
[Feature] 터치 영역 커스텀을 위한 PickleIconButtonWithTouchCustom 공통 컴포넌트 추가

### DIFF
--- a/presentation/src/main/java/com/smtm/pickle/presentation/common/extension/ModifierExt.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/common/extension/ModifierExt.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
-import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.smtm.pickle.presentation.designsystem.theme.PickleTheme
@@ -76,30 +75,5 @@ fun Modifier.clearFocusOnBackgroundTab(
                 if (distance > touchSlop) return@awaitEachGesture
             }
         }
-    }
-}
-
-// 아이콘 관련 공통 컴포넌트용
-fun Modifier.customLayout(
-    contentSize: Dp,
-    layoutSize: Dp
-) = this.layout { measurable, constraints ->
-    val contentPx = contentSize.roundToPx()
-    val layoutPx = layoutSize.roundToPx()
-
-    // 컨텐츠 영역 측정
-    val placeable = measurable.measure(
-        constraints.copy(
-            minWidth = contentPx,
-            minHeight = contentPx,
-            maxWidth = contentPx,
-            maxHeight = contentPx
-        )
-    )
-
-    // 실제 레이아웃 차지 공간 설정
-    layout(layoutPx, layoutPx) {
-        val offset = (layoutPx - contentPx) / 2
-        placeable.place(offset, offset)
     }
 }

--- a/presentation/src/main/java/com/smtm/pickle/presentation/designsystem/components/button/PickleIconButton.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/designsystem/components/button/PickleIconButton.kt
@@ -15,10 +15,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.smtm.pickle.presentation.common.extension.customLayout
 import com.smtm.pickle.presentation.designsystem.theme.dimension.Dimensions
 
 @Composable
@@ -70,10 +70,27 @@ fun PickleIconButtonWithTouchCustom(
 
     Box(
         modifier = modifier
-            .customLayout(
-                contentSize = touchSize,
-                layoutSize = layoutSize
-            ) // 클릭 이벤트 및 리플 효과 설정
+            .layout { measurable, constraints ->
+                val contentPx = touchSize.roundToPx()
+                val layoutPx = layoutSize.roundToPx()
+
+                // 컨텐츠 영역 측정
+                val placeable = measurable.measure(
+                    constraints.copy(
+                        minWidth = contentPx,
+                        minHeight = contentPx,
+                        maxWidth = contentPx,
+                        maxHeight = contentPx
+                    )
+                )
+
+                // 실제 레이아웃 차지 공간 설정
+                layout(layoutPx, layoutPx) {
+                    val offset = (layoutPx - contentPx) / 2
+                    placeable.place(offset, offset)
+                }
+            }
+            // 클릭 이벤트 및 리플 효과 설정
             .clickable(
                 interactionSource = interactionSource,
                 indication = ripple(


### PR DESCRIPTION
### ♟️ Issue
#19 

### **✨ 주요 변경 사항**
- 눈에 보이는 아이콘의 사이즈와 실제 차지하는 영역의 크기를 다르게 설정할 수 있도록 구현.
- 필요한 값만 입력할 수 있도록 변경했습니다.

### **✅ 체크리스트**
- [x]  🌱 merge 브랜치 확인
- [x] 🛠️ 빌드 성공
- [x]  💬 관련 이슈 연결 ([Closes | Fixes | Resolves] #123)

### 🔍 중점 리뷰 사항
-

### **📸 스크린샷**
> e.g. `<img width="45%" src="링크" />`
