### PR TITLE
[Feature]: PickleIconButton 공통 컴포넌트 추가

### DIFF
--- a/presentation/src/main/java/com/smtm/pickle/presentation/designsystem/components/button/PickleIconButton.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/designsystem/components/button/PickleIconButton.kt
@@ -1,0 +1,33 @@
+package com.smtm.pickle.presentation.designsystem.components.button
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Dp
+import com.smtm.pickle.presentation.designsystem.theme.dimension.Dimensions
+
+@Composable
+fun PickleIconButton(
+    painter: Painter,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    buttonSize: Dp = Dimensions.iconMedium,
+    iconSize: Dp = Dimensions.iconMedium,
+    contentDescription: String? = null,
+) {
+    IconButton(
+        modifier = modifier.size(buttonSize),
+        enabled = enabled,
+        onClick = onClick,
+    ) {
+        Image(
+            modifier = Modifier.size(iconSize),
+            painter = painter,
+            contentDescription = contentDescription,
+        )
+    }
+}

--- a/presentation/src/main/java/com/smtm/pickle/presentation/designsystem/theme/Theme.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/designsystem/theme/Theme.kt
@@ -1,11 +1,13 @@
 package com.smtm.pickle.presentation.designsystem.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.unit.dp
 import com.smtm.pickle.presentation.designsystem.theme.color.LightColorScheme
 import com.smtm.pickle.presentation.designsystem.theme.color.LightPickleColors
 import com.smtm.pickle.presentation.designsystem.theme.color.LightSemanticColors
@@ -31,6 +33,7 @@ fun PickleTheme(
         LocalPickleColors provides pickleColors,
         LocalSemanticColors provides semanticColors,
         LocalPickleTypography provides typography,
+        LocalMinimumInteractiveComponentSize provides 0.dp,
     ) {
         MaterialTheme(
             colorScheme = colorScheme,


### PR DESCRIPTION
 ### ♟️ Issue                                                                                                       
  - #19                                                                 
                                                                                                                     
  ### **✨ 주요 변경 사항**                                                                                           
  - **테마에서 `LocalMinimumInteractiveComponentSize provides 0.dp` 설정**                                           
    - Material3 인터랙티브 컴포넌트(`IconButton`, `Button` 등)의 강제 최소 터치 영역(48dp) 제거                      
    - 디자인 스펙에 맞는 정확한 크기 제어 가능                                                                       
    - `IconButton`뿐 아니라 향후 다른 버튼 컴포넌트에서도 동일하게 적용됨                                            
  - **`PickleIconButton` 공통 컴포넌트 추가**                                                                        
    - `Icon` 대신 `Image` 사용 → `tint = Color.Unspecified` 보일러플레이트 제거                                      
    - Material3 `IconButton`을 그대로 활용하여 리플 효과 유지                                                        
    - `buttonSize` / `iconSize` 두 가지 파라미터로 버튼 영역과 아이콘 크기를 간결하게 제어                           
  - **기존 PR #20 대비 개선점**                                                                                      
    - `PickleIcon` 컴포넌트 제거 (현재는 기본 파라미터 래퍼 수준의 역할만 수행하고 있어, 구조 단순화를 위해 정리)
    - `Modifier.customLayout` 커스텀 측정 로직 제거 (`Modifier.size`로 충분)                                         
    - 3개 파일 142줄 → 2개 파일 약 35줄로 축소                                                                       
                                                                                                                     
  ### **✅ 체크리스트**                                                                                              
  - [x] 🌱 merge 브랜치 확인                                                                                         
  - [x] 🛠️ 빌드 성공                                                                                                 
  - [x] 💬 관련 이슈 연결 (Closes #19)                                                                               
                                                                                                                     
  ### 🔍 중점 리뷰 사항                                                                                              
  - `LocalMinimumInteractiveComponentSize provides 0.dp`를 테마 레벨에 적용하는 것이 프로젝트 전반에 미치는 영향     
  (기존 Material3 컴포넌트 사용처에서 터치 영역이 의도치 않게 줄어들지 않는지)                                       
  - `Icon` 대신 `Image`를 사용하는 방향에 대한 의견 (tint가 필요한 단색 벡터 아이콘의 경우 별도 컴포넌트가 필요할 수 
  있음)         