### PR TITLE
[Fix] API 명세 변경에 따른 리프레시 로직 수정

### DIFF
--- a/data/src/main/java/com/smtm/pickle/data/mapper/AuthMapper.kt
+++ b/data/src/main/java/com/smtm/pickle/data/mapper/AuthMapper.kt
@@ -1,6 +1,6 @@
 package com.smtm.pickle.data.mapper
 
-import com.smtm.pickle.data.source.remote.model.LoginResponse
+import com.smtm.pickle.data.source.remote.model.auth.LoginResponse
 import com.smtm.pickle.domain.model.auth.AuthToken
 
 fun LoginResponse.toDomain(): AuthToken = AuthToken(

--- a/data/src/main/java/com/smtm/pickle/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/smtm/pickle/data/repository/AuthRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.smtm.pickle.data.repository
 import com.smtm.pickle.data.mapper.toDomain
 import com.smtm.pickle.data.source.remote.api.AuthService
 import com.smtm.pickle.data.source.remote.datasource.GoogleAuthDataSource
-import com.smtm.pickle.data.source.remote.model.LoginRequest
+import com.smtm.pickle.data.source.remote.model.auth.LoginRequest
 import com.smtm.pickle.domain.model.auth.AuthToken
 import com.smtm.pickle.domain.model.auth.SocialLoginType
 import com.smtm.pickle.domain.provider.TokenProvider

--- a/data/src/main/java/com/smtm/pickle/data/source/remote/api/AuthService.kt
+++ b/data/src/main/java/com/smtm/pickle/data/source/remote/api/AuthService.kt
@@ -1,7 +1,7 @@
 package com.smtm.pickle.data.source.remote.api
 
-import com.smtm.pickle.data.source.remote.model.LoginRequest
-import com.smtm.pickle.data.source.remote.model.LoginResponse
+import com.smtm.pickle.data.source.remote.model.auth.LoginRequest
+import com.smtm.pickle.data.source.remote.model.auth.LoginResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 

--- a/data/src/main/java/com/smtm/pickle/data/source/remote/api/RefreshTokenApi.kt
+++ b/data/src/main/java/com/smtm/pickle/data/source/remote/api/RefreshTokenApi.kt
@@ -1,16 +1,17 @@
 package com.smtm.pickle.data.source.remote.api
 
-import com.smtm.pickle.data.source.remote.model.LoginResponse
-import retrofit2.http.Header
+import com.smtm.pickle.data.source.remote.model.auth.LoginResponse
+import com.smtm.pickle.data.source.remote.model.auth.RefreshTokenRequest
+import retrofit2.http.Body
 import retrofit2.http.POST
 
 /** Authenticator 내부에서만 사용할 API */
 interface RefreshTokenApi {
 
     /** Authenticator 내부 호출용 API */
-    @POST("auth/refresh")
+    @POST("token")
     suspend fun refreshToken(
-        @Header("Authorization") refreshToken: String
+        @Body refreshToken: RefreshTokenRequest
     ): LoginResponse
 
 }

--- a/data/src/main/java/com/smtm/pickle/data/source/remote/auth/TokenRefresher.kt
+++ b/data/src/main/java/com/smtm/pickle/data/source/remote/auth/TokenRefresher.kt
@@ -1,6 +1,7 @@
 package com.smtm.pickle.data.source.remote.auth
 
 import com.smtm.pickle.data.source.remote.api.RefreshTokenApi
+import com.smtm.pickle.data.source.remote.model.auth.RefreshTokenRequest
 import com.smtm.pickle.domain.model.auth.AuthToken
 import com.smtm.pickle.domain.provider.TokenProvider
 import kotlinx.coroutines.CancellationException
@@ -36,7 +37,9 @@ class TokenRefresher @Inject constructor(
                 ?: return@withLock null
 
             val response = runCatching {
-                refreshApi.refreshToken("Bearer $refreshToken")
+                refreshApi.refreshToken(
+                    RefreshTokenRequest(refreshToken = refreshToken)
+                )
             }.getOrElse { e ->
                 if (e is CancellationException) throw e
                 // 리프레시 토큰 만료 또는 무효일 때만 로그아웃 처리

--- a/data/src/main/java/com/smtm/pickle/data/source/remote/model/auth/LoginRequest.kt
+++ b/data/src/main/java/com/smtm/pickle/data/source/remote/model/auth/LoginRequest.kt
@@ -1,4 +1,4 @@
-package com.smtm.pickle.data.source.remote.model
+package com.smtm.pickle.data.source.remote.model.auth
 
 import kotlinx.serialization.Serializable
 

--- a/data/src/main/java/com/smtm/pickle/data/source/remote/model/auth/LoginResponse.kt
+++ b/data/src/main/java/com/smtm/pickle/data/source/remote/model/auth/LoginResponse.kt
@@ -1,4 +1,4 @@
-package com.smtm.pickle.data.source.remote.model
+package com.smtm.pickle.data.source.remote.model.auth
 
 import kotlinx.serialization.Serializable
 

--- a/data/src/main/java/com/smtm/pickle/data/source/remote/model/auth/RefreshTokenRequest.kt
+++ b/data/src/main/java/com/smtm/pickle/data/source/remote/model/auth/RefreshTokenRequest.kt
@@ -1,0 +1,8 @@
+package com.smtm.pickle.data.source.remote.model.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RefreshTokenRequest(
+    val refreshToken: String
+)


### PR DESCRIPTION
### ♟️ Issue
-

### **✨ 주요 변경 사항**
- 토큰 리프레시 API의 엔드포인트가 `/auth/refresh`에서 `/token`으로 변경되었습니다.
- 기존에 Header로 전달하던 리프레시 토큰을 Request Body에 담아 보내도록 수정했습니다.
- 관련 데이터 모델(`LoginRequest`, `LoginResponse`)들을 `auth` 하위 패키지로 이동하고, `RefreshTokenRequest` 모델을 추가했습니다.

### **✅ 체크리스트**
- [x]  🌱 merge 브랜치 확인
- [x]  🛠️ 빌드 성공
- [ ]  💬 관련 이슈 연결 ([Closes | Fixes | Resolves] #123)

### 🔍 중점 리뷰 사항
-

### **📸 스크린샷**
> e.g. `<img width="45%" src="링크" />`
