### PR TITLE
[Fix] 홈 화면 월별 수입/지출 합계가 3개월 합산으로 계산되는 버그 수정

### DIFF
--- a/presentation/src/main/java/com/smtm/pickle/presentation/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/home/HomeViewModel.kt
@@ -95,7 +95,7 @@ class HomeViewModel @Inject constructor(
                     YearMonth.from(it.occurredOn) == yearMonth
                 }
                 val summary = currentMonthLedgers.summarize()
-                val ledgerCalendarDays = currentMonthLedgers.toLedgerCalendarDays()
+                val ledgerCalendarDays = ledgers.toLedgerCalendarDays()
 
                 _uiState.update { state ->
                     state.copy(


### PR DESCRIPTION
### ♟️ Issue
- Closes #52

### **✨ 주요 변경 사항**
- 홈 화면 월별 수입/지출 합계가 3개월 합산으로 계산되는 버그 수정

### **✅ 체크리스트**
- [x]  🌱 merge 브랜치 확인
- [x]  🛠️ 빌드 성공
- [x]  💬 관련 이슈 연결

### 🔍 중점 리뷰 사항
-

### **📸 스크린샷**
