### PR TITLE
[Fix] 스낵바 UX 개선

### DIFF
--- a/presentation/src/main/java/com/smtm/pickle/presentation/designsystem/components/snackbar/SnackbarHost.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/designsystem/components/snackbar/SnackbarHost.kt
@@ -90,7 +90,6 @@ fun SnackbarHost(
                     if (alignment == Alignment.TopCenter) -fullHeight else fullHeight
                 }
             ) + fadeOut(animationSpec = tween(300)),
-            label = snackbar?.id ?: ""
         ) {
             lastValidData?.let { data ->
                 AnimatedContent(

--- a/presentation/src/main/java/com/smtm/pickle/presentation/designsystem/components/snackbar/model/SnackbarData.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/designsystem/components/snackbar/model/SnackbarData.kt
@@ -1,10 +1,7 @@
 package com.smtm.pickle.presentation.designsystem.components.snackbar.model
 
-import java.util.UUID
-
 /**
  * 커스텀 스낵바 데이터
- * @param id 스낵바 구분을 위한 아이디
  * @param message 메시지
  * @param iconType 아이콘 타입
  * @param position 스낵바 위치
@@ -13,7 +10,6 @@ import java.util.UUID
  * @param duration 지속 시간
  */
 data class SnackbarData(
-    val id: String = UUID.randomUUID().toString(),
     val message: String,
     val iconType: SnackbarIconType = SnackbarIconType.None,
     val position: SnackbarPosition = SnackbarPosition.AboveSystemNavigation,


### PR DESCRIPTION
### ♟️ Issue
- #59 

### **✨ 주요 변경 사항**
- 스낵바 데이터를 구분하기 위한 `id` 파라미터를 추가합니다.
- 연속으로 스낵바가 표시될 때 깜빡임을 추가해 새 스낵바가 뜨는 모습이 보이도록 변경
  - 떠있을 때 스낵바가 사라지고, 뜨는 애니메이션을 기다리지 않게 하기 위해 깜빡이는 느낌으로 부여

- 기존 show 함수를 두고, 즉시 새 스낵바를 표시하는 showImmediately 구현
- 현재 동작 방식
  - show(): 첫 번째 스낵바 표시 -> 새 스낵바가 있을 경우 Queue에 대기 시켜 현재 스낵바가 종료된 후 보이도록 함 (꼭 봐야하는 중요한 내용이 있는 경우 사용)
  - showImmediately(): 첫 번째 스낵바 표시 -> 현재 스낵바를 즉시 종료하고 새 스낵바 표시 (스낵바

### **✅ 체크리스트**
- [x]  🌱 merge 브랜치 확인
- [x]  🛠️ 빌드 성공
- [x]  💬 관련 이슈 연결 ([Closes | Fixes | Resolves] #123)

### 🔍 중점 리뷰 사항
-

### **📸 스크린샷**
> e.g. `<img width="45%" src="링크" />`

- showImmediately() 적용 영상

https://github.com/user-attachments/assets/64ebe297-f900-4be6-a233-8943abd7c259

