### PR TITLE
[Fix] 로그인 이동 시 백스택 전체 제거

### DIFF
--- a/presentation/src/main/java/com/smtm/pickle/presentation/mypage/navigation/MyPageNavigation.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/mypage/navigation/MyPageNavigation.kt
@@ -41,7 +41,7 @@ fun NavGraphBuilder.myPageDestinations(navController: NavController) {
             },
             onNavigateToLogin = {
                 navController.navigate(LoginRoute) {
-                    popUpTo(navController.graph.findStartDestination().id) {
+                    popUpTo(navController.graph.id) {
                         inclusive = true
                     }
                     launchSingleTop = true


### PR DESCRIPTION
### **✨ 주요 변경 사항**
- 로그인 화면으로 이동할 때 `popUpTo(navController.graph.id)`를 사용하도록 수정하여, 현재 내비게이션 그래프의 모든 백스택을 제거하도록 변경합니다.

### **✅ 체크리스트**
- [x]  🌱 merge 브랜치 확인
- [x]  🛠️ 빌드 성공

### 🔍 중점 리뷰 사항
- 

### **📸 스크린샷**
> e.g. `<img width="45%" src="링크" />`
