### PR TITLE
[Feature] 로그아웃 및 세션 만료 GlobalNavEvent 적용

### DIFF
--- a/app/src/main/java/com/smtm/pickle/MainActivity.kt
+++ b/app/src/main/java/com/smtm/pickle/MainActivity.kt
@@ -76,7 +76,7 @@ class MainActivity : ComponentActivity() {
 
                 LaunchedEffect(Unit) {
                     sessionEventBus.sessionExpired.collect {
-                        handleGlobalNavEvent(GlobalNavEvent.SessionExpired("세션이 만료되었습니다. 다시 로그인해주세요."))
+                        handleGlobalNavEvent(GlobalNavEvent.SessionExpired(getString(R.string.global_session_expired)))
                     }
                 }
 

--- a/app/src/main/java/com/smtm/pickle/MainActivity.kt
+++ b/app/src/main/java/com/smtm/pickle/MainActivity.kt
@@ -5,18 +5,30 @@ import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.navigation.compose.rememberNavController
+import com.smtm.pickle.domain.event.SessionEventBus
+import com.smtm.pickle.presentation.designsystem.components.snackbar.PickleSnackbar
+import com.smtm.pickle.presentation.designsystem.components.snackbar.SnackbarHost
+import com.smtm.pickle.presentation.designsystem.components.snackbar.model.SnackbarState
 import com.smtm.pickle.presentation.designsystem.theme.PickleTheme
 import com.smtm.pickle.presentation.navigation.GlobalNavEvent
 import com.smtm.pickle.presentation.navigation.PickleNavHost
 import com.smtm.pickle.presentation.navigation.route.LoginRoute
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var sessionEventBus: SessionEventBus
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -34,6 +46,9 @@ class MainActivity : ComponentActivity() {
         setContent {
             PickleTheme {
                 val navController = rememberNavController()
+                val snackbarState = remember { SnackbarState() }
+                val scope = rememberCoroutineScope()
+
                 val handleGlobalNavEvent: (GlobalNavEvent) -> Unit = remember(navController) {
                     { event ->
                         when (event) {
@@ -47,8 +62,21 @@ class MainActivity : ComponentActivity() {
                                 navController.navigate(LoginRoute) {
                                     popUpTo(navController.graph.id) { inclusive = true }
                                 }
+                                scope.launch {
+                                    snackbarState.show(
+                                        PickleSnackbar.snackbarShort(
+                                            message = event.message
+                                        )
+                                    )
+                                }
                             }
                         }
+                    }
+                }
+
+                LaunchedEffect(Unit) {
+                    sessionEventBus.sessionExpired.collect {
+                        handleGlobalNavEvent(GlobalNavEvent.SessionExpired("세션이 만료되었습니다. 다시 로그인해주세요."))
                     }
                 }
 
@@ -56,6 +84,8 @@ class MainActivity : ComponentActivity() {
                     navController = navController,
                     onGlobalNavEvent = handleGlobalNavEvent,
                 )
+
+                SnackbarHost(snackbarState)
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Pickle</string>
+
+    <string name="global_session_expired">세션이 만료되었습니다. 다시 로그인해주세요.</string>
 </resources>

--- a/data/src/main/java/com/smtm/pickle/data/di/DataModule.kt
+++ b/data/src/main/java/com/smtm/pickle/data/di/DataModule.kt
@@ -1,6 +1,8 @@
 package com.smtm.pickle.data.di
 
+import com.smtm.pickle.data.event.SessionEventBusImpl
 import com.smtm.pickle.data.source.local.provider.TokenProviderImpl
+import com.smtm.pickle.domain.event.SessionEventBus
 import com.smtm.pickle.domain.provider.TokenProvider
 import dagger.Binds
 import dagger.Module
@@ -15,5 +17,10 @@ abstract class DataModule {
     abstract fun bindTokenProvider(
         tokenProviderImpl: TokenProviderImpl
     ): TokenProvider
+
+    @Binds
+    abstract fun bindSessionEventBus(
+        sessionEventBusImpl: SessionEventBusImpl
+    ): SessionEventBus
 
 }

--- a/data/src/main/java/com/smtm/pickle/data/event/SessionEventBusImpl.kt
+++ b/data/src/main/java/com/smtm/pickle/data/event/SessionEventBusImpl.kt
@@ -1,0 +1,17 @@
+package com.smtm.pickle.data.event
+
+import com.smtm.pickle.domain.event.SessionEventBus
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SessionEventBusImpl @Inject constructor() : SessionEventBus {
+    private val _channel = Channel<Unit>(Channel.BUFFERED)
+    override val sessionExpired: Flow<Unit> = _channel.receiveAsFlow()
+    override suspend fun emitSessionExpired() {
+        _channel.send(Unit)
+    }
+}

--- a/data/src/main/java/com/smtm/pickle/data/event/SessionEventBusImpl.kt
+++ b/data/src/main/java/com/smtm/pickle/data/event/SessionEventBusImpl.kt
@@ -9,9 +9,9 @@ import javax.inject.Singleton
 
 @Singleton
 class SessionEventBusImpl @Inject constructor() : SessionEventBus {
-    private val _channel = Channel<Unit>(Channel.BUFFERED)
+    private val _channel = Channel<Unit>(Channel.CONFLATED)
     override val sessionExpired: Flow<Unit> = _channel.receiveAsFlow()
     override suspend fun emitSessionExpired() {
-        _channel.send(Unit)
+        _channel.trySend(Unit)
     }
 }

--- a/data/src/main/java/com/smtm/pickle/data/source/remote/auth/TokenRefresher.kt
+++ b/data/src/main/java/com/smtm/pickle/data/source/remote/auth/TokenRefresher.kt
@@ -2,6 +2,7 @@ package com.smtm.pickle.data.source.remote.auth
 
 import com.smtm.pickle.data.source.remote.api.RefreshTokenApi
 import com.smtm.pickle.data.source.remote.model.auth.RefreshTokenRequest
+import com.smtm.pickle.domain.event.SessionEventBus
 import com.smtm.pickle.domain.model.auth.AuthToken
 import com.smtm.pickle.domain.provider.TokenProvider
 import kotlinx.coroutines.CancellationException
@@ -15,6 +16,7 @@ import javax.inject.Singleton
 class TokenRefresher @Inject constructor(
     private val tokenProvider: TokenProvider,
     private val refreshApi: RefreshTokenApi,
+    private val sessionEventBus: SessionEventBus,
 ) {
     private val refreshLock = Mutex()
 
@@ -45,6 +47,7 @@ class TokenRefresher @Inject constructor(
                 // 리프레시 토큰 만료 또는 무효일 때만 로그아웃 처리
                 if (e is HttpException && (e.code() == 401 || e.code() == 400)) {
                     tokenProvider.clearToken()
+                    sessionEventBus.emitSessionExpired()
                 }
                 return@withLock null
             }

--- a/domain/src/main/java/com/smtm/pickle/domain/event/SessionEventBus.kt
+++ b/domain/src/main/java/com/smtm/pickle/domain/event/SessionEventBus.kt
@@ -1,0 +1,9 @@
+package com.smtm.pickle.domain.event
+
+import kotlinx.coroutines.flow.Flow
+
+/** 세션 상태 변화를 앱 전역에 전달하는 이벤트 버스 */
+interface SessionEventBus {
+    val sessionExpired: Flow<Unit>
+    suspend fun emitSessionExpired()
+}

--- a/presentation/src/main/java/com/smtm/pickle/presentation/mypage/navigation/MyPageNavigation.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/mypage/navigation/MyPageNavigation.kt
@@ -12,7 +12,7 @@ import com.smtm.pickle.presentation.mypage.profile.nicknamesetting.NicknameSetti
 import com.smtm.pickle.presentation.navigation.route.AlarmSettingRoute
 import com.smtm.pickle.presentation.navigation.route.LedgerCreateRoute
 import com.smtm.pickle.presentation.navigation.route.LedgerDetailRoute
-import com.smtm.pickle.presentation.navigation.route.LoginRoute
+import com.smtm.pickle.presentation.navigation.GlobalNavEvent
 import com.smtm.pickle.presentation.navigation.route.MyLedgerRoute
 import com.smtm.pickle.presentation.navigation.route.MyProfileRoute
 import com.smtm.pickle.presentation.navigation.route.NicknameSettingRoute
@@ -22,7 +22,10 @@ import com.smtm.pickle.presentation.setting.alarmsetting.AlarmSettingScreen
 
 private const val PrivacyPolicyUrl = "https://www.notion.so/303e42cd9924802abd39eabb3685ca3b"
 
-fun NavGraphBuilder.myPageDestinations(navController: NavController) {
+fun NavGraphBuilder.myPageDestinations(
+    navController: NavController,
+    onGlobalNavEvent: (GlobalNavEvent) -> Unit,
+) {
     composable<MyLedgerRoute> {
         MyLedgerScreen(
             onNavigateToLedgerDetail = { ledgerId ->
@@ -45,14 +48,7 @@ fun NavGraphBuilder.myPageDestinations(navController: NavController) {
                     context.startActivity(intent)
                 }
             },
-            onNavigateToLogin = {
-                navController.navigate(LoginRoute) {
-                    popUpTo(navController.graph.id) {
-                        inclusive = true
-                    }
-                    launchSingleTop = true
-                }
-            },
+            onGlobalNavEvent = onGlobalNavEvent,
             onNavigateBack = {
                 navController.popBackStack()
             },

--- a/presentation/src/main/java/com/smtm/pickle/presentation/navigation/PickleNavHost.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/navigation/PickleNavHost.kt
@@ -45,7 +45,10 @@ fun PickleNavHost(
             // 심판하기
             verdictDestinations(navController)
             // 마이페이지
-            myPageDestinations(navController)
+            myPageDestinations(
+                navController = navController,
+                onGlobalNavEvent = onGlobalNavEvent
+            )
         }
     )
 }

--- a/presentation/src/main/java/com/smtm/pickle/presentation/setting/SettingScreen.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/setting/SettingScreen.kt
@@ -31,6 +31,7 @@ import com.smtm.pickle.presentation.designsystem.components.snackbar.PickleSnack
 import com.smtm.pickle.presentation.designsystem.components.snackbar.SnackbarHost
 import com.smtm.pickle.presentation.designsystem.components.snackbar.model.SnackbarState
 import com.smtm.pickle.presentation.designsystem.theme.PickleTheme
+import com.smtm.pickle.presentation.navigation.GlobalNavEvent
 import com.smtm.pickle.presentation.setting.components.SettingGroup
 import com.smtm.pickle.presentation.setting.model.SettingItem
 import com.smtm.pickle.presentation.setting.model.SettingSection
@@ -40,7 +41,7 @@ import com.smtm.pickle.presentation.setting.model.SettingTrailingType
 fun SettingScreen(
     viewModel: SettingViewModel = hiltViewModel(),
     onNavigateToPrivacyPolicy: () -> Unit,
-    onNavigateToLogin: () -> Unit,
+    onGlobalNavEvent: (GlobalNavEvent) -> Unit,
     onNavigateBack: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -57,7 +58,7 @@ fun SettingScreen(
                     }
 
                     SettingEffect.NavigateToLogin -> {
-                        onNavigateToLogin()
+                        onGlobalNavEvent(GlobalNavEvent.Logout)
                     }
 
                     SettingEffect.NavigateBack -> {


### PR DESCRIPTION
### **✨ 주요 변경 사항**
- SessionEventBus: 앱 전역 세션 상태 전파를 위한 이벤트 버스 인터페이스 및 구현체 추가
- TokenRefresher: 토큰 갱신 실패(400, 401) 시 세션 만료 이벤트 발행 로직 추가
- MainActivity: 세션 만료 이벤트 구독 및 로그인 화면 이동, 스낵바 알림 표시 처리
- DataModule: SessionEventBus 의존성 바인딩 설정 추가
<br>

- onNavigateToLogin 콜백을 onGlobalNavEvent(GlobalNavEvent.Logout) 호출로 변경
- MyPageNavigation 및 PickleNavHost에서 GlobalNavEvent를 전달받도록 파라미터 수정
- SettingScreen에서 직접 수행하던 로그인 경로 이동 로직을 상위 NavHost로 위임

### **✅ 체크리스트**
- [x]  🌱 merge 브랜치 확인
- [x]  🛠️ 빌드 성공

### 🔍 중점 리뷰 사항
- 기존 작성된 GlobalNavEvent를 사용하고자 한 방향이 맞는지 확인 부탁드립니다

### **📸 스크린샷**
> 디자인 변경사항 없음.
