### PR TITLE
[Feature]: 그냥 사용해보기 구현

### DIFF
--- a/data/src/main/java/com/smtm/pickle/data/di/DataModule.kt
+++ b/data/src/main/java/com/smtm/pickle/data/di/DataModule.kt
@@ -1,6 +1,8 @@
 package com.smtm.pickle.data.di
 
+import com.smtm.pickle.data.source.local.provider.DeviceIdProviderImpl
 import com.smtm.pickle.data.source.local.provider.TokenProviderImpl
+import com.smtm.pickle.domain.provider.DeviceIdProvider
 import com.smtm.pickle.domain.provider.TokenProvider
 import dagger.Binds
 import dagger.Module
@@ -16,4 +18,8 @@ abstract class DataModule {
         tokenProviderImpl: TokenProviderImpl
     ): TokenProvider
 
+    @Binds
+    abstract fun bindDeviceIdProvider(
+        deviceIdProviderImpl: DeviceIdProviderImpl
+    ): DeviceIdProvider
 }

--- a/data/src/main/java/com/smtm/pickle/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/smtm/pickle/data/di/NetworkModule.kt
@@ -60,7 +60,8 @@ object NetworkModule {
         return Interceptor { chain ->
             val originalRequest = chain.request()
 
-            if (originalRequest.url.encodedPath.contains("oauth/login")) {
+            val unauthenticatedPaths = listOf("oauth/login", "oauth/demo")
+            if (unauthenticatedPaths.any { originalRequest.url.encodedPath.contains(it) }) {
                 return@Interceptor chain.proceed(originalRequest)
             }
 

--- a/data/src/main/java/com/smtm/pickle/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/smtm/pickle/data/repository/AuthRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.smtm.pickle.data.mapper.toDomain
 import com.smtm.pickle.data.source.remote.api.AuthService
 import com.smtm.pickle.data.source.remote.api.UserApi
 import com.smtm.pickle.data.source.remote.datasource.GoogleAuthDataSource
+import com.smtm.pickle.data.source.remote.model.auth.DemoLoginRequest
 import com.smtm.pickle.data.source.remote.model.auth.LoginRequest
 import com.smtm.pickle.domain.model.auth.AuthToken
 import com.smtm.pickle.domain.model.auth.SocialLoginType
@@ -46,6 +47,16 @@ class AuthRepositoryImpl @Inject constructor(
             token = idToken,
             type = SocialLoginType.GOOGLE
         )
+    }
+
+    /** 그냥 사용해보기 — deviceId로 데모 계정 발급 */
+    override suspend fun demoLogin(deviceId: String): AuthToken {
+        val response = authService.demoLogin(
+            request = DemoLoginRequest(deviceId = deviceId)
+        )
+        val authToken = response.toDomain()
+        tokenProvider.saveToken(authToken)
+        return authToken
     }
 
     override suspend fun logout() {

--- a/data/src/main/java/com/smtm/pickle/data/source/local/provider/DeviceIdProviderImpl.kt
+++ b/data/src/main/java/com/smtm/pickle/data/source/local/provider/DeviceIdProviderImpl.kt
@@ -2,37 +2,21 @@ package com.smtm.pickle.data.source.local.provider
 
 import android.content.Context
 import android.provider.Settings
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringPreferencesKey
-import com.smtm.pickle.data.di.Preference
 import com.smtm.pickle.domain.provider.DeviceIdProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.first
-import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class DeviceIdProviderImpl @Inject constructor(
     @ApplicationContext private val context: Context,
-    @Preference private val dataStore: DataStore<Preferences>,
 ) : DeviceIdProvider {
-
-    private val DEMO_DEVICE_ID = stringPreferencesKey("demo_device_id")
 
     override suspend fun getOrCreate(): String {
         // ANDROID_ID: 앱 재설치 후에도 동일 기기에서 동일한 값 유지 (팩토리 리셋 시에만 변경)
+        // ANDROID_ID를 사용할 수 없는 기기에서는 데모 로그인을 지원하지 않음
         val androidId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
-        if (!androidId.isNullOrEmpty()) return androidId
-
-        // Fallback: ANDROID_ID를 사용할 수 없는 경우 (일부 에뮬레이터 등)
-        val existing = dataStore.data.first()[DEMO_DEVICE_ID]
-        if (existing != null) return existing
-
-        val newId = UUID.randomUUID().toString()
-        dataStore.edit { it[DEMO_DEVICE_ID] = newId }
-        return newId
+        return androidId.takeIf { !it.isNullOrEmpty() }
+            ?: error("지원하지 않는 기기")
     }
 }

--- a/data/src/main/java/com/smtm/pickle/data/source/local/provider/DeviceIdProviderImpl.kt
+++ b/data/src/main/java/com/smtm/pickle/data/source/local/provider/DeviceIdProviderImpl.kt
@@ -1,0 +1,38 @@
+package com.smtm.pickle.data.source.local.provider
+
+import android.content.Context
+import android.provider.Settings
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.smtm.pickle.data.di.Preference
+import com.smtm.pickle.domain.provider.DeviceIdProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.first
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DeviceIdProviderImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @Preference private val dataStore: DataStore<Preferences>,
+) : DeviceIdProvider {
+
+    private val DEMO_DEVICE_ID = stringPreferencesKey("demo_device_id")
+
+    override suspend fun getOrCreate(): String {
+        // ANDROID_ID: 앱 재설치 후에도 동일 기기에서 동일한 값 유지 (팩토리 리셋 시에만 변경)
+        val androidId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+        if (!androidId.isNullOrEmpty()) return androidId
+
+        // Fallback: ANDROID_ID를 사용할 수 없는 경우 (일부 에뮬레이터 등)
+        val existing = dataStore.data.first()[DEMO_DEVICE_ID]
+        if (existing != null) return existing
+
+        val newId = UUID.randomUUID().toString()
+        dataStore.edit { it[DEMO_DEVICE_ID] = newId }
+        return newId
+    }
+}

--- a/data/src/main/java/com/smtm/pickle/data/source/remote/api/AuthService.kt
+++ b/data/src/main/java/com/smtm/pickle/data/source/remote/api/AuthService.kt
@@ -1,5 +1,6 @@
 package com.smtm.pickle.data.source.remote.api
 
+import com.smtm.pickle.data.source.remote.model.auth.DemoLoginRequest
 import com.smtm.pickle.data.source.remote.model.auth.LoginRequest
 import com.smtm.pickle.data.source.remote.model.auth.LoginResponse
 import retrofit2.http.Body
@@ -9,6 +10,9 @@ interface AuthService {
 
     @POST("oauth/login")
     suspend fun socialLogin(@Body request: LoginRequest): LoginResponse
+
+    @POST("oauth/demo")
+    suspend fun demoLogin(@Body request: DemoLoginRequest): LoginResponse
 
     @POST("logout")
     suspend fun logout()

--- a/data/src/main/java/com/smtm/pickle/data/source/remote/model/auth/DemoLoginRequest.kt
+++ b/data/src/main/java/com/smtm/pickle/data/source/remote/model/auth/DemoLoginRequest.kt
@@ -1,0 +1,8 @@
+package com.smtm.pickle.data.source.remote.model.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DemoLoginRequest(
+    val deviceId: String,
+)

--- a/domain/src/main/java/com/smtm/pickle/domain/provider/DeviceIdProvider.kt
+++ b/domain/src/main/java/com/smtm/pickle/domain/provider/DeviceIdProvider.kt
@@ -1,0 +1,6 @@
+package com.smtm.pickle.domain.provider
+
+interface DeviceIdProvider {
+
+    suspend fun getOrCreate(): String
+}

--- a/domain/src/main/java/com/smtm/pickle/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/smtm/pickle/domain/repository/AuthRepository.kt
@@ -12,6 +12,8 @@ interface AuthRepository {
 
     suspend fun loginWithGoogle(): AuthToken
 
+    suspend fun demoLogin(deviceId: String): AuthToken
+
     suspend fun logout()
 
     suspend fun withdrawAccount()

--- a/domain/src/main/java/com/smtm/pickle/domain/usecase/auth/DemoLoginUseCase.kt
+++ b/domain/src/main/java/com/smtm/pickle/domain/usecase/auth/DemoLoginUseCase.kt
@@ -1,0 +1,17 @@
+package com.smtm.pickle.domain.usecase.auth
+
+import com.smtm.pickle.domain.common.utils.runSuspendCatching
+import com.smtm.pickle.domain.model.auth.AuthToken
+import com.smtm.pickle.domain.provider.DeviceIdProvider
+import com.smtm.pickle.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class DemoLoginUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val deviceIdProvider: DeviceIdProvider,
+) {
+    suspend operator fun invoke(): Result<AuthToken> = runSuspendCatching {
+        val deviceId = deviceIdProvider.getOrCreate()
+        authRepository.demoLogin(deviceId = deviceId)
+    }
+}

--- a/presentation/src/main/java/com/smtm/pickle/presentation/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/login/LoginScreen.kt
@@ -96,7 +96,8 @@ fun LoginScreen(
                     viewModel.handleLoginError(message)
                 }
             )
-        }
+        },
+        onDemoLogin = viewModel::loginWithDemo,
     )
 
     SnackbarHost(snackbarState)
@@ -108,6 +109,7 @@ fun LoginContent(
     uiState: LoginUiState,
     onGoogleLogin: () -> Unit,
     onKakaoLogin: () -> Unit,
+    onDemoLogin: () -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -135,6 +137,7 @@ fun LoginContent(
                 uiState = uiState,
                 onGoogleLogin = onGoogleLogin,
                 onKakaoLogin = onKakaoLogin,
+                onDemoLogin = onDemoLogin,
             )
             Spacer(modifier = Modifier.height(40.dp))
         }
@@ -149,6 +152,7 @@ private fun LoginContentPreview() {
             uiState = LoginUiState.Idle,
             onGoogleLogin = {},
             onKakaoLogin = {},
+            onDemoLogin = {},
         )
     }
 }

--- a/presentation/src/main/java/com/smtm/pickle/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/login/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.smtm.pickle.presentation.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.smtm.pickle.domain.model.auth.AuthToken
+import com.smtm.pickle.domain.usecase.auth.DemoLoginUseCase
 import com.smtm.pickle.domain.usecase.auth.GoogleLoginUseCase
 import com.smtm.pickle.domain.usecase.auth.KakaoLoginUseCase
 import com.smtm.pickle.domain.usecase.user.GetFirstLoginUseCase
@@ -22,6 +23,7 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val kakaoLoginUseCase: KakaoLoginUseCase,
     private val googleLoginUseCase: GoogleLoginUseCase,
+    private val demoLoginUseCase: DemoLoginUseCase,
     private val getFirstLoginUseCase: GetFirstLoginUseCase,
     private val setFirstLoginUseCase: SetFirstLoginUseCase,
 ) : ViewModel() {
@@ -43,6 +45,10 @@ class LoginViewModel @Inject constructor(
         handleLogin {
             kakaoLoginUseCase(token = token)
         }
+    }
+
+    fun loginWithDemo() {
+        handleLogin { demoLoginUseCase() }
     }
 
     fun handleLoginError(message: String) {

--- a/presentation/src/main/java/com/smtm/pickle/presentation/login/components/ButtonSection.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/login/components/ButtonSection.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -28,6 +30,7 @@ fun ButtonSection(
     uiState: LoginUiState,
     onKakaoLogin: () -> Unit,
     onGoogleLogin: () -> Unit,
+    onDemoLogin: () -> Unit = {},
 ) {
     Column(modifier = modifier) {
         Button(
@@ -80,6 +83,20 @@ fun ButtonSection(
                 text = stringResource(R.string.login_google_start),
                 style = PickleTheme.typography.body4Medium,
                 color = PickleTheme.colors.gray700
+            )
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        TextButton(
+            onClick = onDemoLogin,
+            enabled = uiState !is LoginUiState.Loading,
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        ) {
+            Text(
+                text = stringResource(R.string.login_demo_start),
+                style = PickleTheme.typography.body4Medium,
+                color = PickleTheme.colors.gray500
             )
         }
     }

--- a/presentation/src/main/java/com/smtm/pickle/presentation/login/components/ButtonSection.kt
+++ b/presentation/src/main/java/com/smtm/pickle/presentation/login/components/ButtonSection.kt
@@ -11,9 +11,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -21,6 +19,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.smtm.pickle.presentation.R
+import com.smtm.pickle.presentation.designsystem.components.button.PickleButton
 import com.smtm.pickle.presentation.designsystem.theme.PickleTheme
 import com.smtm.pickle.presentation.login.LoginUiState
 
@@ -86,19 +85,14 @@ fun ButtonSection(
             )
         }
 
-        Spacer(modifier = Modifier.height(20.dp))
+        Spacer(modifier = Modifier.height(11.dp))
 
-        TextButton(
+        PickleButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.login_demo_start),
             onClick = onDemoLogin,
             enabled = uiState !is LoginUiState.Loading,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
-        ) {
-            Text(
-                text = stringResource(R.string.login_demo_start),
-                style = PickleTheme.typography.body4Medium,
-                color = PickleTheme.colors.gray500
-            )
-        }
+        )
     }
 }
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <!-- Login -->
     <string name="login_kakao_start">카카오톡으로 시작하기</string>
     <string name="login_google_start">구글 계정으로 시작하기</string>
+    <string name="login_demo_start">그냥 사용해보기</string>
     <string name="login_tooltip_fast">3초만에 로그인하기!</string>
 
     <!-- Nickname -->


### PR DESCRIPTION
### ♟️ Issue
-

### **✨ 주요 변경 사항**
   - DeviceIdProvider 추가: ANDROID_ID 기반 기기 식별자 발급, ANDROID_ID 없는 기기에서는 데모 로그인 미지원
   - 데모 로그인 API 연동: `POST oauth/demo` 엔드포인트 추가 및 NetworkModule 인증 예외 경로 확장
   - DemoLoginUseCase 추가: DeviceIdProvider로 기기 ID 발급 후 AuthRepository.demoLogin 호출
   - 로그인 화면에 '그냥 사용해보기' 버튼(PickleButton) 추가 및 플로우 연결

### **✅ 체크리스트**
- [x] 🌱 merge 브랜치 확인
- [x] 🛠️ 빌드 성공

### 🔍 중점 리뷰 사항


### **📸 스크린샷**
<img width="360" alt="image" src="https://github.com/user-attachments/assets/7e7626bf-64af-4da1-a69d-f3d066cfb7c6" />